### PR TITLE
test: add intl default locale

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,7 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
+        <ini name="intl.default_locale" value="en_EN" />
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
     </php>
 


### PR DESCRIPTION
With this change the testsuite is green. No matter which default locale is set on the local machine.